### PR TITLE
MFA-271 fix for fileURLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "2.0.1",
     "name": "com.mwaysolutions.cordova.webviewplugin",
     "main": "www/webview-plugin.js",
     "cordova_name": "InAppBrowser",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
   xmlns:rim="http://www.blackberry.com/ns/widgets"
   xmlns:android="http://schemas.android.com/apk/res/android"
   id="com.mwaysolutions.cordova.webviewplugin"
-  version="2.0.0">
+  version="2.0.1">
   <name>Webview</name>
   <description>Cordova Webview Plugin</description>
   <license></license>

--- a/src/ios/WebViewController.m
+++ b/src/ios/WebViewController.m
@@ -367,8 +367,6 @@ alpha:			1.0 \
     }
     else
     {
-        NSURL *root = [NSBundle mainBundle].resourceURL;
-        url = [root URLByAppendingPathComponent:url.path];
         NSAssert([[NSFileManager defaultManager] fileExistsAtPath:url.path], @"");
         [webView loadFileURL:url allowingReadAccessToURL:[url URLByDeletingLastPathComponent]];
     }


### PR DESCRIPTION
Turns out the file URLs provided to the plugin are supposed to be absolute. In that case, adding resourceURL makes no sense and would break behavior.